### PR TITLE
Re-implement via a meta-attribute trait.

### DIFF
--- a/lib/MooseX/Does/Delegated.pm
+++ b/lib/MooseX/Does/Delegated.pm
@@ -10,38 +10,15 @@ BEGIN {
 	$MooseX::Does::Delegated::VERSION   = '0.004';
 }
 
-use Moose::Role;
 
-around DOES => sub {
-	my ($orig, $self, $role) = @_;
-	return 1 if $self->$orig($role);
-	return unless blessed($self);
-	for my $attr ($self->meta->get_all_attributes) {
-		next unless $attr->has_handles;
-		my $handles = $attr->handles;
-		next if ref $handles;
-		next unless $attr->has_value($self) || $attr->is_lazy;
-		return 1 if $role eq $handles;
-		return 1 if Class::MOP::class_of($handles)->does_role($role);
-	}
-	return;
-};
+use Moose::Exporter;
+use MooseX::Does::Delegated::Meta::Attribute::Trait;
 
-# Allow import method to work, yet hide it from role method list.
-our @ISA = do {
-	package # Hide from CPAN indexer too.
-	MooseX::Does::Delegated::__ANON__::0001;
-	use Moose::Util qw(ensure_all_roles);
-	sub import {
-		no warnings qw(uninitialized);
-		my $class = shift;
-		ensure_all_roles('Moose::Object', $class)
-			if $_[0] =~ /^[-](?:everywhere|rafl)/;
-	}
-	__PACKAGE__;
-};
-
-no Moose::Role;
+Moose::Exporter->setup_import_methods(
+    class_metaroles => {
+        attribute => ['MooseX::Does::Delegates::Meta::Attribute::Trait'],
+    },
+);
 
 __PACKAGE__
 __END__
@@ -54,23 +31,24 @@ MooseX::Does::Delegated - allow your class's DOES method to respond the affirmat
 
    use strict;
    use Test::More;
-   
+
    {
       package HttpGet;
       use Moose::Role;
       requires 'get';
    };
-   
+
    {
       package UserAgent;
       use Moose;
       with qw( HttpGet );
       sub get { ... };
    };
-   
+
    {
-      package Spider;
+      package WoollySpider;
       use Moose;
+      use MooseX::Does::Delegated
       has ua => (
          is         => 'ro',
          does       => 'HttpGet',
@@ -79,26 +57,12 @@ MooseX::Does::Delegated - allow your class's DOES method to respond the affirmat
       );
       sub _build_ua { UserAgent->new };
    };
-   
+
    my $woolly = Spider->new;
-   
-   # Note that the default Moose implementation of DOES
-   # ignores the fact that Spider has delegated the HttpGet
-   # role to its "ua" attribute.
-   #
-   ok(     $woolly->DOES('Spider') );
-   ok( not $woolly->DOES('HttpGet') );
-   
-   Moose::Util::apply_all_roles(
-      'Spider',
-      'MooseX::Does::Delegated',
-   );
-   
-   # Our reimplemented DOES pays attention to delegated roles.
-   #
+
    ok( $woolly->DOES('Spider') );
    ok( $woolly->DOES('HttpGet') );
-   
+
    done_testing;
 
 =head1 DESCRIPTION
@@ -107,22 +71,8 @@ According to L<UNIVERSAL> the point of C<DOES> is that it allows you
 to check whether an object does a role without caring about I<how>
 it does the role.
 
-However, the default Moose implementation of C<DOES> (which you can
-of course override!) only checks whether the object does the role via
-inheritance or the application of a role to a class.
-
-This module overrides your object's C<DOES> method, allowing it to
-respond the affirmative to delegated roles. This module is a standard
-Moose role, so it can be used like this:
-
-   with qw( MooseX::Does::Delegated );
-
-Alternatively, if you wish to apply this role ubiqitously (i.e. to all
-Moose objects in your application) - as is your prerogative - you can use:
-
-   use MooseX::Does::Delegated -everywhere;
-
-This will apply the role to the Moose::Object base class.
+This module tells Moose that after setting up the delegation to a Role
+it needs to also declare that the class now performs that role.
 
 =head1 BUGS
 

--- a/lib/MooseX/Does/Delegated/Meta/Attribute/Trait.pm
+++ b/lib/MooseX/Does/Delegated/Meta/Attribute/Trait.pm
@@ -1,0 +1,22 @@
+package MooseX::Does::Delegates::Meta::Attribute::Trait;
+use Moose::Role;
+Moose::Util::meta_attribute_alias('Delegated');
+
+after install_delegation  => sub {
+    my ($self) = @_;
+
+    return unless $self->has_handles;
+
+    my $handles = $self->handles;
+    if (ref $handles) {
+        return unless blessed($handles) && $handles->isa('Moose::Meta::TypeConstraint::Role');
+        $handles = $handles->role;
+    }
+
+    Moose::Util::_load_user_class($handles);
+    my $role_meta = Class::MOP::class_of($handles);
+    $self->associated_class->add_role($role_meta);
+};
+
+1
+__END__

--- a/t/02synopsis.t
+++ b/t/02synopsis.t
@@ -34,6 +34,7 @@ use Test::More;
 {
 	package Spider;
 	use Moose;
+    use MooseX::Does::Delegated;
 	has ua => (
 		is         => 'ro',
 		does       => 'HttpGet',
@@ -43,23 +44,9 @@ use Test::More;
 	sub _build_ua { UserAgent->new };
 };
 
-my $woolly = Spider->new;
+my $spider = Spider->new;
 
-# Note that the default Moose implementation of DOES
-# ignores the fact that Spider has delegated the HttpGet
-# role to its "ua" attribute.
-#
-ok(     $woolly->DOES('Spider') );
-ok( not $woolly->DOES('HttpGet') );
-
-Moose::Util::apply_all_roles(
-	'Spider',
-	'MooseX::Does::Delegated',
-);
-
-# Our reimplemented DOES pays attention to delegated roles.
-#
-ok( $woolly->DOES('Spider') );
-ok( $woolly->DOES('HttpGet') );
+ok( $spider->DOES('Spider') );
+ok( $spider->DOES('HttpGet') );
 
 done_testing;

--- a/t/03_additional_cases.t
+++ b/t/03_additional_cases.t
@@ -1,0 +1,127 @@
+=head1 PURPOSE
+
+Test the example from the L<MooseX::Does::Delegated> SYNOPSIS section.
+
+=head1 AUTHOR
+
+Toby Inkster E<lt>tobyink@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is copyright (c) 2012 by Toby Inkster.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut
+
+use strict;
+use Test::More;
+
+ {
+     package Foo::Bar;
+     use Moose::Role;
+
+     requires 'foo';
+     requires 'bar';
+
+     package Foo::Baz;
+     use Moose;
+
+     sub foo { 'Foo::Baz::FOO' }
+     sub bar { 'Foo::Baz::BAR' }
+     sub baz { 'Foo::Baz::BAZ' }
+
+     package Foo::Thing;
+     use Moose;
+     use MooseX::Does::Delegated;
+
+     has 'thing' => (
+         is      => 'rw',
+         isa     => 'Foo::Baz',
+         handles => 'Foo::Bar',
+     );
+
+     package Foo::OtherThing;
+     use Moose;
+     use Moose::Util::TypeConstraints;
+     use MooseX::Does::Delegated;
+
+     has 'other_thing' => (
+         is      => 'rw',
+         isa     => 'Foo::Baz',
+         handles => Moose::Util::TypeConstraints::find_type_constraint('Foo::Bar'),
+     );
+ }
+
+
+{
+    my $foo = Foo::Thing->new();
+    ok($foo->does('Foo::Bar'));
+    ok(not $foo->does('Foo::Baz'));
+}
+
+{
+    my $foo = Foo::OtherThing->new();
+    ok($foo->does('Foo::Bar'));
+    ok(not $foo->does('Foo::Baz'));
+}
+
+{
+    package Foo::Blub;
+    use Moose::Role;
+    requires 'glub';
+
+    package Foo::Bonk;
+    use Moose::Role;
+    with qw(Foo::Bar Foo::Blub);
+    sub foo {1}
+    sub bar {1}
+    sub glub {1}
+
+    package Foo::YAThing;
+    use Moose;
+    use MooseX::Does::Delegated;
+    has 'ya_thing' => (
+        is      => 'rw',
+        does    => 'Foo::Bonk',
+        handles => 'Foo::Bonk',
+    );
+}
+
+{
+    my $foo = Foo::YAThing->new;
+    ok($foo->does('Foo::Bonk'));
+    ok($foo->does('Foo::Bar'));
+    ok($foo->does('Foo::Blub'));
+}
+
+
+{
+
+    package Foo::OneLessThing;
+    use Moose;
+    has 'thing' => (
+         is      => 'rw',
+         isa     => 'Foo::Baz',
+         handles => 'Foo::Bar',
+     );
+
+    package Foo::OneMoreThing;
+    use Moose;
+    use MooseX::Does::Delegated;
+    extends qw(Foo::OneLessThing);
+}
+
+
+{
+    my $no_foo = Foo::OneLessThing->new();
+    ok(not $no_foo->does('Foo::Bar'));
+}
+TODO: {
+    local $TODO = "probably won't work until we're in core";
+    my $foo = Foo::OneMoreThing->new();
+    ok($foo->does('Foo::Bar'));
+}
+
+done_testing;


### PR DESCRIPTION
So when migrating this module to Moose directly the feedback was that overriding DOES is an icky way to go about doing this. If for no other reason that it's the very edge of what cares about whether a class does a role or not.

The suggestion was to reimplement it as a metaclass trait that sets up Moose so that it reports the right thing anyway. That's what this patch does. Specifically we hook into `Moose::Meta::Attribute` and after the `install_delegation` call we add the role (if we delegated to a role) into the associated metaclass' list of roles.

This should mean that introspection works on every turtle, all the way down.

Additionally we test some more edge cases that would be expected to work. My goal is to get this tested and merge it into Moose directly next quarter.
